### PR TITLE
Update composition-eu-eps.fsh

### DIFF
--- a/input/fsh/profiles/composition-eu-eps.fsh
+++ b/input/fsh/profiles/composition-eu-eps.fsh
@@ -25,7 +25,7 @@ Description: "Clinical document used to represent a Patient Summary for the scop
 * author ^short = "Who and/or what authored the Patient Summary"
 * author ^definition = "Identifies who is responsible for the information in the Patient Summary, not necessarily who typed it in."
   * ^slicing.discriminator[0].type = #type
-  * ^slicing.discriminator[0].path = "valueReference.resolve()"
+  * ^slicing.discriminator[0].path = "reference.resolve()"
   * ^slicing.ordered = false
   * ^slicing.rules = #open
   * ^short = "Sliced per type of author"

--- a/input/fsh/profiles/composition-eu-eps.fsh
+++ b/input/fsh/profiles/composition-eu-eps.fsh
@@ -25,7 +25,7 @@ Description: "Clinical document used to represent a Patient Summary for the scop
 * author ^short = "Who and/or what authored the Patient Summary"
 * author ^definition = "Identifies who is responsible for the information in the Patient Summary, not necessarily who typed it in."
   * ^slicing.discriminator[0].type = #type
-  * ^slicing.discriminator[0].path = "reference.resolve()"
+  * ^slicing.discriminator[0].path = "$this.resolve()"
   * ^slicing.ordered = false
   * ^slicing.rules = #open
   * ^short = "Sliced per type of author"


### PR DESCRIPTION
This pull request includes a minor but important correction to the `input/fsh/profiles/composition-eu-eps.fsh` file. The change updates the slicing discriminator's path to ensure proper resolution of references.

Key change:

* Updated the slicing discriminator path from `"valueReference.resolve()"` to `"reference.resolve()"` to align with the correct FHIR specification for resolving references. (`[input/fsh/profiles/composition-eu-eps.fshL28-R28](diffhunk://#diff-0844f5402365cb72f4f9d47fbe920fa8c4a9a57811b0a46b8d13e8c289881c74L28-R28)`)
fixes #23