### PR TITLE
Update slicing discriminator and author references in composition-eu-eps.fsh

### DIFF
--- a/input/fsh/profiles/composition-eu-eps.fsh
+++ b/input/fsh/profiles/composition-eu-eps.fsh
@@ -24,17 +24,15 @@ Description: "Clinical document used to represent a Patient Summary for the scop
 * date ^short = "PS date"
 * author ^short = "Who and/or what authored the Patient Summary"
 * author ^definition = "Identifies who is responsible for the information in the Patient Summary, not necessarily who typed it in."
-  * ^slicing.discriminator[0].type = #type
+  * ^slicing.discriminator[0].type = #profile
   * ^slicing.discriminator[0].path = "resolve()"
   * ^slicing.ordered = false
   * ^slicing.rules = #open
   * ^short = "Sliced per type of author"
   * ^definition = "Sliced per type of author"
 * author contains
-    practictionerRole 0..* and
-    device 0..*
-* author[practictionerRole] only Reference ( $practitionerRole-eu-core )
-* author[device] only Reference ( Device )
+    eps-author 0..*
+* author[eps-author] only Reference ($practitioner-eu-core or $practitionerRole-eu-core or Device or $organization-eu-core)
 
 * title ^short = "Patient Summary"
 * title ^definition = "Official human-readable label for the composition.\r\n\r\nFor this document should be \"Patient Summary\" or any equivalent translation"

--- a/input/fsh/profiles/composition-eu-eps.fsh
+++ b/input/fsh/profiles/composition-eu-eps.fsh
@@ -22,17 +22,9 @@ Description: "Clinical document used to represent a Patient Summary for the scop
 * subject ^definition = "Who or what the composition is about. \r\nIn general a composition can be about a person, (patient or healthcare practitioner), a device (e.g. a machine) or even a group of subjects (such as a document about a herd of livestock, or a set of patients that share a common exposure).\r\nFor the PS the subject is always the patient."
 // * encounter only Reference ( EncounterEuEps )
 * date ^short = "PS date"
-* author ^short = "Who and/or what authored the Patient Summary"
-* author ^definition = "Identifies who is responsible for the information in the Patient Summary, not necessarily who typed it in."
-  * ^slicing.discriminator[0].type = #profile
-  * ^slicing.discriminator[0].path = "resolve()"
-  * ^slicing.ordered = false
-  * ^slicing.rules = #open
-  * ^short = "Sliced per type of author"
-  * ^definition = "Sliced per type of author"
-* author contains
-    eps-author 0..*
-* author[eps-author] only Reference ($practitioner-eu-core or $practitionerRole-eu-core or Device or $organization-eu-core)
+* author only Reference ($practitioner-eu-core or $practitionerRole-eu-core or Device or $organization-eu-core or Patient or RelatedPerson)
+  * ^short = "Who and/or what authored the Patient Summary"
+  * ^definition = "Identifies who is responsible for the information in the Patient Summary, not necessarily who typed it in."
 
 * title ^short = "Patient Summary"
 * title ^definition = "Official human-readable label for the composition.\r\n\r\nFor this document should be \"Patient Summary\" or any equivalent translation"


### PR DESCRIPTION
This pull request includes updates to the slicing and author definitions in the `composition-eu-eps.fsh` file to simplify the profile and explicitly point to Organization and Practitioner

### Changes to slicing and author definitions:

* Updated the slicing discriminator's `type` from `#type` to `#profile` to better reflect the intended slicing mechanism. (`[input/fsh/profiles/composition-eu-eps.fshL27-R35](diffhunk://#diff-0844f5402365cb72f4f9d47fbe920fa8c4a9a57811b0a46b8d13e8c289881c74L27-R35)`)
* Replaced the `author` slices `practitionerRole` and `device` with a single slice `eps-author`, which allows references to multiple entities (`$practitioner-eu-core`, `$practitionerRole-eu-core`, `Device`, or `$organization-eu-core`). This change simplifies the structure and expands the flexibility of author references. (`[input/fsh/profiles/composition-eu-eps.fshL27-R35](diffhunk://#diff-0844f5402365cb72f4f9d47fbe920fa8c4a9a57811b0a46b8d13e8c289881c74L27-R35)`)