### PR TITLE
Add example observation for gestational age in days and update profile description and restrict quantity to ucum & days

### DIFF
--- a/input/fsh/examples/observation-pregnancyGestationalAge-eps-example.fsh
+++ b/input/fsh/examples/observation-pregnancyGestationalAge-eps-example.fsh
@@ -1,0 +1,13 @@
+Instance: EPSExampleObservationPregnancyGestationalAge
+InstanceOf: ObservationPregnancyGestationalAgeEuEps
+Title: "Observation Example: Pregnancy Gestational Age"
+Description: "Example observation for gestational age in days."
+Usage: #example
+* status = #final
+* code = $loinc#18185-9 "Gestational age"
+* subject = Reference(Patient/example)
+* effectiveDateTime = "2026-05-01"
+* valueQuantity.value = 182
+* valueQuantity.unit = "days"
+* valueQuantity.system = $ucum
+* valueQuantity.code = #d

--- a/input/fsh/profiles/observation-pregnancyGestationalAge-eps.fsh
+++ b/input/fsh/profiles/observation-pregnancyGestationalAge-eps.fsh
@@ -2,7 +2,7 @@ Profile: ObservationPregnancyGestationalAgeEuEps
 Parent: Observation
 Id: observation-pregnancy-gestationalAge-eu-eps
 Title: "Observation Pregnancy - Gestational Age (EPS)"
-Description: "This profile constrains the Observation resource to represent gestational age."
+Description: "This profile constrains the Observation resource to represent gestational age in days."
 
 * insert SetFmmAndStatusRule (1, draft)
 
@@ -16,6 +16,9 @@ Description: "This profile constrains the Observation resource to represent gest
 * effective[x] only dateTime
 * valueQuantity only Quantity
 * valueQuantity
+  * unit = "days"
+  * system = $ucum
+  * code = #d
 * bodySite ..0
 * method ..0
 * specimen ..0


### PR DESCRIPTION
This pull request enhances the gestational age observation profile by specifying that the value must be recorded in days and provides a concrete example instance. The main changes clarify the unit of measurement and improve the documentation and examples for implementers.

Profile constraints for gestational age in days:

* Updated the `Description` in the `ObservationPregnancyGestationalAgeEuEps` profile to specify that gestational age is represented in days.
* Added constraints to the `valueQuantity` element in the profile to require the unit "days", the UCUM system, and the code "d".

Example instance:

* Added a new example instance, `EPSExampleObservationPregnancyGestationalAge`, demonstrating how to record gestational age in days using the updated profile.