### PR TITLE
Add effective[x] cardinality 1..

### DIFF
--- a/input/fsh/profiles/diagnosticReport-eps.fsh
+++ b/input/fsh/profiles/diagnosticReport-eps.fsh
@@ -25,6 +25,7 @@ Description: "This profile represents the constraints applied to the DiagnosticR
 
 * subject.reference insert ObligationIpsPopulateIfKnownHandle
 
+* effective[x] 1..
 * effective[x] insert ObligationIpsPopulateIfKnownDisplay
 
 * effectiveDateTime insert ObligationIpsAbleToPopulateDisplay


### PR DESCRIPTION
This pull request introduces a constraint to the `effective[x]` field in the `diagnosticReport-eps.fsh` profile, making it a required field to be IPS compatible

* Profile validation:
  * The `effective[x]` field is now required (`1..` cardinality) in the `diagnosticReport-eps.fsh` profile, ensuring that an effective date or period must be specified for each `DiagnosticReport`.