### PR TITLE
Add expansion parameters - fix ips-comp-1 usage

### DIFF
--- a/input/fsh/profiles/composition-eu-eps.fsh
+++ b/input/fsh/profiles/composition-eu-eps.fsh
@@ -57,7 +57,6 @@ Description: """This profile defines how the Composition resource is used to rep
 * section.code only http://hl7.org/fhir/uv/ips/StructureDefinition/CodeableConcept-uv-ips
 * section.text 1..
 * section.text only Narrative
-* section obeys ips-comp-1
 
 * section.section ..0
 * section contains
@@ -82,7 +81,7 @@ Description: """This profile defines how the Composition resource is used to rep
 
 // ==  EPS Problem Section ==
 
-* section[sectionProblems]
+* section[sectionProblems] obeys ips-comp-1
   * insert SectionComRules ( 
       EPS Problems Section, 
       The EPS problem section lists and describes clinical problems or conditions currently being monitored for the patient., 
@@ -98,7 +97,7 @@ Description: """This profile defines how the Composition resource is used to rep
 
 // == EPS Allergies and Intolerances Section  ==
 
-* section[sectionAllergies]
+* section[sectionAllergies] obeys ips-comp-1
   * insert SectionComRules ( 
      	EPS Allergies and Intolerances Section, 
       This section documents the relevant allergies or intolerances for that patient\, describing the kind of reaction - e.g. rash\, anaphylaxis\,.. - preferably the agents that cause it; and optionally the criticality and the certainty of the allergy. At a minimum\, it should list currently active and any relevant historical allergies and adverse reactions. If no information about allergies is available\, or if no allergies are known this should be clearly documented in the section., 
@@ -116,7 +115,7 @@ Description: """This profile defines how the Composition resource is used to rep
 
 // === EPS Medication Summary Section ===
 
-* section[sectionMedications]
+* section[sectionMedications] obeys ips-comp-1
   * insert SectionComRules ( 
       EPS Medication Summary Section, 
       The medication summary section contains a description of the patient's medications relevant for the scope of the patient summary. The actual content could depend on the jurisdiction\, it could report:
@@ -138,7 +137,6 @@ Description: """This profile defines how the Composition resource is used to rep
 // === EPS Immunizations Section ===
 
 * section[sectionImmunizations]
-
   * insert SectionComRules (EPS Immunizations Section, 
   The Immunizations Section defines a patient's current immunization status and pertinent immunization history. The primary use case for the Immunization Section is to enable communication of a patient's immunization status. The section includes the current immunization status\, and may contain the entire immunization history that is relevant to the period of time being summarized.,
   http://loinc.org#11369-6)
@@ -178,7 +176,7 @@ Description: """This profile defines how the Composition resource is used to rep
 
 ///=== EPS Medical Devices Section
 
-* section[sectionMedicalDevices] 
+* section[sectionMedicalDevices]
   * insert SectionComRules (EPS Medical Devices Section, 
   The medical devices section contains narrative text and coded entries describing the patient history of medical device use.,
   http://loinc.org#46264-8)
@@ -199,7 +197,7 @@ Description: """This profile defines how the Composition resource is used to rep
 * section[sectionAlert]
   * insert SectionComRules ( 
       EPS Alerts Section, 
-      The alerts section flags potential concerns and/or dangers to/from the patient and may also include obstacles to care., 
+      The alerts section flags potential concerns and/or dangers to/from the patient and may also include obstacles to care.,
       http://loinc.org#104605-1)
 
   * entry only Reference(Flag or DocumentReference)
@@ -212,7 +210,7 @@ Description: """This profile defines how the Composition resource is used to rep
 
 // ==== EPS Results Section
 
-* section[sectionResults]  
+* section[sectionResults]
   * insert SectionComRules ( 
       EPS Results Section, 
       This section assembles relevant observation results collected on the patient or produced on in-vitro biologic specimens collected from the patient. Some of these results may be laboratory results\, others may be anatomic pathology results\, others\, radiology results\, and others\, clinical results., 
@@ -490,9 +488,6 @@ Description: "Either section.entry or emptyReason are present"
 * severity = #error
 * expression = "(entry.reference.exists() or emptyReason.exists())"
 * xpath = "(/f:entry.reference and not /f:emptyReason) or (not(/f:emptyReason) and /f:entry.reference)"
-
-
-
 
 
 

--- a/input/fsh/sct-expansion-params.fsh
+++ b/input/fsh/sct-expansion-params.fsh
@@ -4,4 +4,4 @@ Title: "Parameters for Terminology expansion using Snomed-CT international editi
 Description: "This parameter resource is used to specify the system version of international SNOMED CT to be used in the terminology service."
 Usage: #definition
 * parameter.name = "system-version"
-* parameter.valueCanonical = "http://snomed.info/sct|http://snomed.info/sct/900000000000207008"
+* parameter.valueUri = "http://snomed.info/sct|http://snomed.info/sct/900000000000207008"

--- a/input/pagecontent/expansion-params.md
+++ b/input/pagecontent/expansion-params.md
@@ -1,0 +1,3 @@
+### Expansion Parameters
+
+{% include expansion-params.xhtml %}

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -75,6 +75,8 @@ pages:
     title: Downloads
   dependencies.md:
     title: Dependencies
+  expansion-params.md:
+    title: Expansion Parameters
   introduction.md:
     title: Introduction
   authors.md:
@@ -188,6 +190,8 @@ parameters: #see https://confluence.hl7.org/display/FHIR/Implementation+Guide+Pa
     - http://terminology.ehdsi.eu/ValueSet/eHDSISubstance
     - http://terminology.ehdsi.eu/ValueSet/eHDSIBloodGroup
     - http://terminology.ehdsi.eu/ValueSet/eHDSISocialHistory
+  path-expansion-params: ../resources/Parameters-exp-params.json
+
 
 
 # see https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters
@@ -250,6 +254,7 @@ menu:
     Known/Open Issues: knownIssues.html
     Download: downloads.html
     Dependencies: dependencies.html
+    Expansion parameters: expansion-params.html
     #  Change Log: changes.html <== NOT FOR THIS VERSION
     Copyright: copyright.html
     Cross-version Analysis: crossversionanalysis.html


### PR DESCRIPTION
This pull request introduces several improvements and corrections related to terminology expansion parameters, documentation, and FHIR profile constraints. The most significant changes involve enforcing the `ips-comp-1` rule on specific `Composition.section` elements, updating the SNOMED CT expansion parameter, and adding new documentation for expansion parameters.

### FHIR Profile Constraint Updates

* Enforced the `ips-comp-1` rule on the `sectionProblems`, `sectionAllergies`, and `sectionMedications` subsections within the `Composition` profile, ensuring these sections comply with the required invariant. The general `section obeys ips-comp-1` constraint was removed in favor of these targeted applications. [[1]](diffhunk://#diff-0844f5402365cb72f4f9d47fbe920fa8c4a9a57811b0a46b8d13e8c289881c74L60) [[2]](diffhunk://#diff-0844f5402365cb72f4f9d47fbe920fa8c4a9a57811b0a46b8d13e8c289881c74L85-R84) [[3]](diffhunk://#diff-0844f5402365cb72f4f9d47fbe920fa8c4a9a57811b0a46b8d13e8c289881c74L101-R100) [[4]](diffhunk://#diff-0844f5402365cb72f4f9d47fbe920fa8c4a9a57811b0a46b8d13e8c289881c74L119-R118)

### Terminology Expansion Parameter Updates

* Changed the SNOMED CT expansion parameter from `valueCanonical` to the correct `valueUri` type in `sct-expansion-params.fsh`, ensuring compatibility with FHIR expectations.
* Added a new `path-expansion-params` entry to the implementation guide configuration, linking to the relevant parameters resource.

### Documentation and Navigation Improvements

* Added a new markdown page `expansion-params.md` and included it in the navigation and menu, providing users with documentation on terminology expansion parameters. [[1]](diffhunk://#diff-8ebaa1d56e6ec616a3373a1d75ec5d0329cf2934aa204270c5f94169e91b1980R1-R3) [[2]](diffhunk://#diff-9bd0b4a19606858a6c686eb415df9224a0610668a04e98aafbc7985cacb4b0e4R78-R79) [[3]](diffhunk://#diff-9bd0b4a19606858a6c686eb415df9224a0610668a04e98aafbc7985cacb4b0e4R257)

### Minor Cleanups

* Removed extraneous blank lines from the `composition-eu-eps.fsh` profile file.

closes https://github.com/hl7-eu/eps/issues/61